### PR TITLE
feat: Update Go version and add GOEXPERIMENT variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: stable
+          go-version: '^1.25.3'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552
         with:
@@ -32,3 +32,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOEXPERIMENT: "greenteagc"


### PR DESCRIPTION
Updated Go version to '^1.25.3' and added GOEXPERIMENT environment variable.

This speeds up app by atl east 10% due to the Greentea Garbage collector of Go