### PR TITLE
ci: add a verify step before releasing a new version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ project_name: recaller
 
 before:
   hooks:
+    - ./verify.sh
     # You may remove this if you don't use go modules.
     - go mod tidy
     # you may remove this if you don't need go generate

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ Copyright @ Naren Yellavula (Please give us a star ⭐ here: https://github.com/
 
 	var cmdHistory = &cobra.Command{
 		Use:   "history",
-		Short: "Print Recaller usage guide",
+		Short: "Fetch history sorted by time and frequency. Pass a string to find a match. Ex: recaller history s3api",
 		Long:  fmt.Sprintf("%s\n%s", asciiLogo, "Suggest list of past %d most frequently used commands"),
 		Args:  cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard rails to ensure CLI version output matches release tag.
+
+if [[ ${GORELEASER_SNAPSHOT:-} == "true" ]]; then
+  exit 0
+fi
+
+version_file="version.go"
+if [[ ! -f "$version_file" ]]; then
+  echo "verify.sh: missing ${version_file}" >&2
+  exit 1
+fi
+
+if ! version_line=$(grep -E 'const[[:space:]]+version[[:space:]]*=' "$version_file"); then
+  echo "verify.sh: could not find version constant in ${version_file}" >&2
+  exit 1
+fi
+
+if [[ ! $version_line =~ \"([^\"]+)\" ]]; then
+  echo "verify.sh: failed to parse version constant in ${version_file}" >&2
+  exit 1
+fi
+
+file_version="${BASH_REMATCH[1]}"
+tag_version="${GORELEASER_CURRENT_TAG:-}"
+
+if [[ -z "$tag_version" ]]; then
+  tag_version=$(git describe --tags --exact-match 2>/dev/null || true)
+fi
+
+if [[ -z "$tag_version" ]]; then
+  echo "verify.sh: no release tag detected; aborting" >&2
+  exit 1
+fi
+
+if [[ "$file_version" != "$tag_version" ]]; then
+  cat <<EOF >&2
+verify.sh: version mismatch
+  version.go: ${file_version}
+  release tag: ${tag_version}
+EOF
+  exit 1
+fi
+
+echo "verify.sh: version ${file_version} matches release tag ${tag_version}"

--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package main
 
-const version = "v0.4.0"
+const version = "v0.5.1"


### PR DESCRIPTION
## Description

This PR adds a new verification hook that verifies if version.go and release have same versions.

This is needed to inject right version number into binary and avoid confusion.